### PR TITLE
[WIP]: EDUCATOR-3703: improve JS API demonstration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 script:
-  echo "TODO: implement eslint for ci"
+  echo TODO -- implement eslint for ci
 deploy:
   provider: npm
   user: oscm@edx.org

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/edx/mockprock#readme",
   "dependencies": {
-    "@edx/edx-proctoring": "file:../edx-proctoring"
+    "@edx/edx-proctoring": "git+https://git@github.com/edx/edx-proctoring.git#dahlia/proctoring-master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,4 +20,7 @@
     "url": "https://github.com/edx/mockprock/issues"
   },
   "homepage": "https://github.com/edx/mockprock#readme",
+  "dependencies": {
+    "@edx/edx-proctoring": "file:../edx-proctoring"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/edx/mockprock#readme",
   "dependencies": {
-    "@edx/edx-proctoring": "git+https://git@github.com/edx/edx-proctoring.git#dahlia/proctoring-master"
+    "@edx/edx-proctoring": "git+https://git@github.com/edx/edx-proctoring.git#master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mockprock",
+  "name": "@edx/mockprock",
   "version": "1.0.0",
   "description": "Mock proctoring backend for Open edX",
   "main": "static/index.js",
@@ -8,16 +8,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/davestgermain/mockprock.git"
+    "url": "git+https://github.com/edx/mockprock.git"
   },
   "keywords": [
     "proctoring",
     "OpenedX"
   ],
   "author": "Dave St.Germain",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/davestgermain/mockprock/issues"
+    "url": "https://github.com/edx/mockprock/issues"
   },
-  "homepage": "https://github.com/davestgermain/mockprock#readme"
+  "homepage": "https://github.com/edx/mockprock#readme",
 }

--- a/static/index.js
+++ b/static/index.js
@@ -1,28 +1,47 @@
 import { handlerWrapper } from '@edx/edx-proctoring';
 
+const makeRequest = ({url, method}) => {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open(method, url);
+    xhr.onload = function() {
+      if (this.status >= 200 && this.status < 300) {
+        resolve(JSON.parse(xhr.response));
+      } else {
+        const { status } = this;
+        const { statusText } = xhr;
+        reject({ status, statusText });
+      }
+    };
+    xhr.onerror = function() {
+      const { status } = this;
+      const { statusText } = xhr;
+      reject({ status, statusText });
+    };
+    xhr.send();
+  });
+};
+
 console.log('hello from MockProck!');
 
 class MockProctoringEventHandler {
-  constructur({baseUrl = 'localhost'}) {
+  constructor({baseUrl = 'http://localhost:11136'}) {
     this.baseUrl = baseUrl;
   }
   onStartExamAttempt() {
-    return new Promise(function(resolve, reject) {
-      console.log("MockProctoringEventHandler - onStartExamAttempt() called");
-      setTimeout(resolve, 1000);
-    });
+    console.log("MockProctoringEventHandler - onStartExamAttempt() called");
+    return makeRequest({url: `${this.baseUrl}/desktop/start`, method: 'POST'})
+      .then(response => response.status === "running" ? Promise.resolve() : Promise.reject());
   }
   onEndExamAttempt() {
-    return new Promise((resolve, reject) => {
-      console.log("MockProctoringEventHandler - onEndExamAttempt() called");
-      setTimeout(resolve, 1000);
-    });
+    console.log("MockProctoringEventHandler - onEndExamAttempt() called");
+    return makeRequest({url: `${this.baseUrl}/desktop/stop`, method: 'POST'})
+      .then(response => response.status === "uploading" ? Promise.resolve() : Promise.reject());
   }
   onPing() {
-    return new Promise((resolve) => {
-      console.log("MockProctoringEventHandler - onPing() called");
-      setTimeout(resolve, 100);
-    });
+    console.log("MockProctoringEventHandler - onPing() called");
+    return makeRequest({url: `${this.baseUrl}/desktop/ping`, method: 'GET'})
+      .then(response => response.status === "running" ? Promise.resolve() : Promise.reject());
   }
 }
 

--- a/static/index.js
+++ b/static/index.js
@@ -1,15 +1,15 @@
 console.log('hello from MockProck!');
 
 class MockProctoringEventHandler {
-  onStartExam() {
+  onStartExamAttempt() {
     return new Promise(function(resolve, reject) {
-      console.log("MockProctoringEventHandler - onStartExam() called");
+      console.log("MockProctoringEventHandler - onStartExamAttempt() called");
       setTimeout(resolve, 1000);
     });
   }
-  onEndExam() {
+  onEndExamAttempt() {
     return new Promise((resolve, reject) => {
-      console.log("MockProctoringEventHandler - onEndExam() called");
+      console.log("MockProctoringEventHandler - onEndExamAttempt() called");
       setTimeout(resolve, 1000);
     });
   }

--- a/static/index.js
+++ b/static/index.js
@@ -1,6 +1,11 @@
+import { handlerWrapper } from '@edx/edx-proctoring';
+
 console.log('hello from MockProck!');
 
 class MockProctoringEventHandler {
+  constructur({baseUrl = 'localhost'}) {
+    this.baseUrl = baseUrl;
+  }
   onStartExamAttempt() {
     return new Promise(function(resolve, reject) {
       console.log("MockProctoringEventHandler - onStartExamAttempt() called");
@@ -21,4 +26,4 @@ class MockProctoringEventHandler {
   }
 }
 
-export default MockProctoringEventHandler;
+export default handlerWrapper(MockProctoringEventHandler);


### PR DESCRIPTION
- Inverts/simplifies dependency with edx-proctoring, such that the main export of our proctoring service provider serves as the entry point for our webpack build
- sets us up to publish as a namespaced package
- leverages our new desktop-app endpoints to make the asynchronicity more real, and to put water through those pipes as well

Currently blocked on https://github.com/edx/edx-proctoring/pull/461, which will need to be published to our main npm registry so we can eliminate the relative imports in this PR.