### PR TITLE
Fix travis configuration problem with default-private scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/edx/mockprock.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "proctoring",
     "OpenedX"


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/deployment/npm/#troubleshooting-npm-err-you-need-a-paid-account-to-perform-this-action will fix the issue experienced here: https://travis-ci.org/edx/mockprock/jobs/463566006#L479