### PR TITLE
[BD-6]Run make upgrade in order to update the packages to be compatible wit…

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -4,17 +4,24 @@
 #
 #    make upgrade
 #
-certifi==2019.3.9         # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via flask
-edx-rest-api-client==1.9.2
-flask==1.0.3
-idna==2.8                 # via requests
+click==7.1.2              # via flask
+django-waffle==1.0.0      # via edx-django-utils
+django==2.2.13            # via edx-django-utils
+edx-django-utils==3.2.3   # via edx-rest-api-client
+edx-rest-api-client==5.2.1  # via -r requirements/server.in
+flask==1.1.2              # via -r requirements/server.in
+idna==2.10                # via requests
 itsdangerous==1.1.0       # via flask
-jinja2==2.10.1            # via flask
+jinja2==2.11.2            # via flask
 markupsafe==1.1.1         # via jinja2
-pyjwt==1.7.1
-requests==2.22.0          # via edx-rest-api-client, slumber
+newrelic==5.14.1.144      # via edx-django-utils
+psutil==1.2.1             # via edx-django-utils
+pyjwt==1.7.1              # via -r requirements/server.in, edx-rest-api-client
+pytz==2020.1              # via django
+requests==2.24.0          # via edx-rest-api-client, slumber
 slumber==0.7.1            # via edx-rest-api-client
-urllib3==1.25.3           # via requests
-werkzeug==0.15.4          # via flask
+sqlparse==0.3.1           # via django
+urllib3==1.25.9           # via requests
+werkzeug==1.0.1           # via flask

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=[
         'mockprock',


### PR DESCRIPTION
…h python3.8

Running this with python3.8 is failing with this error:

    code = compile(module, "<werkzeug routing>", "exec")
TypeError: required field "type_ignores" missing from Module

After the upgrade of the packages, the debug server starts as expected

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179